### PR TITLE
Add the Keep Scene Hierarchy flag

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,6 +76,7 @@ int main(int argc, const char* argv[])
         aiComponent_TEXTURES | 
         aiComponent_MATERIALS
     );
+    importer.SetPropertyBool(AI_CONFIG_PP_PTV_KEEP_HIERARCHY, true);
 
     const aiScene* ai_scene = importer.ReadFile(argv[1], 
         aiProcess_Triangulate | 


### PR DESCRIPTION
Adds the Keep Scene Hierarchy flag to preserve the mesh names so the surface tags can be properly applied.